### PR TITLE
docs: add wp-theme-rendered-blocks to examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ This directory contains examples demonstrating how to use various features of th
 | [hybrid-sitemap-apollo](next/hybrid-sitemap-apollo)                                       | Fetches and transforms WordPress sitemaps for clean URL formatting with Next.js.               |
 | [proxied-sitemap-apollo](next/proxied-sitemap-apollo)                                     | Provides a proxied sitemap by transforming WordPress XML sitemaps for SEO-friendly frontend URLs.|
 | [render-blocks-pages-router](next/render-blocks-pages-router)                             | Renders WordPress Blocks with JSX in Next.js, including utilities for hierarchical block data.  |
+| [wp-theme-rendered-blocks](next/wp-theme-rendered-blocks)                             | Demonstrates how to fetch and apply WordPress Global Styles in a Next.js project using the `globalStylesheet` GraphQL field.  |
 
 ## Contributing
 


### PR DESCRIPTION
## Description
Adds an information about the new example (wp-theme-rendered-blocks) into the Readme file of examples folder. 

## Related Issue
- #64 

## Type of Change
- [x] 📝 Documentation update