### PR TITLE
fix: iframe template redundant header/footer and layout issues

### DIFF
--- a/plugins/hwp-previews/templates/hwp-preview.php
+++ b/plugins/hwp-previews/templates/hwp-preview.php
@@ -9,21 +9,28 @@ use HWP\Previews\Preview\Template\Preview_Template_Resolver;
 
 $preview_url = (string) get_query_var( Preview_Template_Resolver::HWP_PREVIEWS_IFRAME_PREVIEW_URL );
 
-get_header();
-
 ?>
 
-    <div style="position: relative; min-height: 100vh;">
-        <iframe
-                src="<?php echo esc_url( $preview_url ); ?>"
-                class="headless-preview-frame"
-                sandbox="allow-scripts allow-same-origin allow-forms"
-                referrerpolicy="no-referrer-when-downgrade"
-                title="Content Preview"
-                style="width: 100%; height: 100vh; border: none;">
-        </iframe>
-    </div>
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+    <head>
+        <?php wp_head(); ?>
+    </head>
 
-<?php
+    <body>
+        <?php wp_body_open(); ?>
 
-get_footer();
+            <div style="position: relative; min-height: 100vh;">
+                <iframe
+                        src="<?php echo esc_url( $preview_url ); ?>"
+                        class="headless-preview-frame"
+                        sandbox="allow-scripts allow-same-origin allow-forms"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Content Preview"
+                        style="width: 100%; height: 100vh; border: none;">
+                </iframe>
+            </div>
+
+        <?php wp_footer(); ?>
+    </body>
+</html>

--- a/plugins/hwp-previews/templates/hwp-preview.php
+++ b/plugins/hwp-previews/templates/hwp-preview.php
@@ -17,17 +17,17 @@ $preview_url = (string) get_query_var( Preview_Template_Resolver::HWP_PREVIEWS_I
         <?php wp_head(); ?>
     </head>
 
-    <body>
+    <body style="overflow: hidden;">
         <?php wp_body_open(); ?>
 
-            <div style="position: relative; min-height: 100vh;">
+            <div style="position: relative;">
                 <iframe
                         src="<?php echo esc_url( $preview_url ); ?>"
                         class="headless-preview-frame"
                         sandbox="allow-scripts allow-same-origin allow-forms"
                         referrerpolicy="no-referrer-when-downgrade"
                         title="Content Preview"
-                        style="width: 100%; height: 100vh; border: none;">
+                        style="width: 100%; height: calc(100vh - var(--wp-admin--admin-bar--height)); border: none;">
                 </iframe>
             </div>
 


### PR DESCRIPTION
- This PR changes the `hwp-preview` with wp_head and wp_footer actions. 
- Adds additional hooks and HTML skeleton. 
- Fixes the layout issues 