### PR TITLE
chore: Updating HOW_WE_WORK.md to specify only one review needed for a PR

### DIFF
--- a/HOW_WE_WORK.md
+++ b/HOW_WE_WORK.md
@@ -34,12 +34,15 @@ We believe in transparent, collaborative development. These guidelines document 
 
 ## Code Review Standards
 
-- Pull requests require 2 approving reviews before merging
+- Pull requests require 1 approving reviews before merging 
 - Reviewers: specify what aspects were reviewed
 - Submitters: indicate which parts need focused attention
 - Provide constructive feedback with supporting evidence
 - Request changes considerately, noting their importance
 - Leverage automation for routine checks ([PR Lint Example](https://github.com/wp-graphql/wp-graphql/blob/develop/.github/workflows/lint-pr.yml))
+
+  >[!NOTE]
+  >A developer should use their own discretion on how many reviews they would like before merging.
 
 ## Community Commitments
 


### PR DESCRIPTION
As per stand up we agreed as a team we felt only one review is needed at this time to help speed up merges.

<!-- Thank you for contributing to our WordPress open source project! -->

## Description
<!-- Please provide a clear and concise description of your changes -->
<!-- What problem does this PR solve? What functionality does it add/improve? -->

## Related Issue
<!-- Please link any related issues here and describe the relationship.
     Examples:
     - "#123 - the issue that the PR resolves"
     - "#456 - this PR addresses part of the issue" -->

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [x] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
