### PR TITLE
feat: Add tooltips to previews

### DIFF
--- a/plugins/hwp-previews/assets/css/hwp-previews.css
+++ b/plugins/hwp-previews/assets/css/hwp-previews.css
@@ -1,0 +1,52 @@
+.form-table td input.hwp-previews-url {
+	width: calc(99% - 24px);
+	display: inline-block;
+}
+
+.hwp-previews-tooltip {
+	position: relative;
+	vertical-align: middle;
+	display: inline-block;
+	margin-right: 0.25rem;
+}
+
+.hwp-previews-tooltip .dashicons {
+	color: #787c82;
+	vertical-align: middle;
+}
+
+.hwp-previews-tooltip .tooltip-text.description {
+	opacity: 0;
+	visibility: hidden;
+	text-align: center;
+	color: #fff;
+	background-color: #1d2327;
+	border-radius: 4px;
+	position: absolute;
+	z-index: 1;
+	width: 180px;
+	padding: 0.5rem;
+	top: 50%;
+	transform: translateY(-50%);
+	vertical-align: middle;
+	margin-left: 0.25rem;
+	transition: opacity 0.12s ease;
+}
+
+.hwp-previews-tooltip .tooltip-text::after {
+	content: "";
+	position: absolute;
+	top: 0;
+	left: -10px;
+	border-width: 6px;
+	border-style: solid;
+	border-color: transparent #1d2327 transparent transparent;
+	top: 50%;
+	transform: translateY(-50%);
+}
+
+.hwp-previews-tooltip:hover .tooltip-text,
+.hwp-previews-tooltip:focus-within .tooltip-text {
+	visibility: visible;
+	opacity: 1;
+}

--- a/plugins/hwp-previews/src/Plugin.php
+++ b/plugins/hwp-previews/src/Plugin.php
@@ -59,6 +59,21 @@ class Plugin {
 	public const PLUGIN_JS_SRC = 'assets/js/hwp-previews.js';
 
 	/**
+	 * The slug for the plugin settings page StyleSheet.
+	 *
+	 * @var string
+	 */
+	public const PLUGIN_CSS_HANDLE = 'hwp-previews-css';
+
+
+	/**
+	 * The path to the CSS file for the plugin.
+	 *
+	 * @var string
+	 */
+	public const PLUGIN_CSS_SRC = 'assets/css/hwp-previews.css';
+
+	/**
 	 * Settings group name used for the plugin.
 	 *
 	 * @var string
@@ -273,7 +288,7 @@ class Plugin {
 	}
 
 	/**
-	 * Enqueues the JavaScript file for the plugin admin area.
+	 * Enqueues the JavaScript and the CSS file for the plugin admin area.
 	 * Todo: if more complexity is added, consider using a separate class Sript_Enqueue.
 	 */
 	public function enqueue_plugin_js(): void {
@@ -289,6 +304,13 @@ class Plugin {
 				$this->version,
 				true
 			);
+
+        	wp_enqueue_style(
+				self::PLUGIN_CSS_HANDLE,
+				trailingslashit( $this->plugin_url ) . self::PLUGIN_CSS_SRC,
+				[],
+				$this->version
+        	);
 		} );
 	}
 
@@ -642,21 +664,35 @@ class Plugin {
 		$fields[] = new Checkbox_Field(
 			'enabled',
 			// translators: %s is the label of the post type.
-			sprintf( __( 'Enable HWP Previews for %s', 'hwp-previews' ), $label )
+			sprintf( __( 'Enable HWP Previews for %s', 'hwp-previews' ), $label ),
+			__( 'Turn preview functionality on or off for this public post type.', 'hwp-previews' )
 		);
-		$fields[] = new Checkbox_Field( 'unique_post_slugs', __( 'Enable unique post slugs for all post statuses', 'hwp-previews' ) );
+		$fields[] = new Checkbox_Field( 
+			'unique_post_slugs', 
+			__( 'Enable unique post slugs for all post statuses', 'hwp-previews' ),
+			__( 'By default WordPress adds unique post slugs to the published posts. This option enforces unique slugs for all post statuses.', 'hwp-previews' ) 
+		);
 
 		if ( $is_hierarchical ) {
-			$fields[] = new Checkbox_Field( 'post_statuses_as_parent', __( 'Allow all post statuses in parents option', 'hwp-previews' ) );
+			$fields[] = new Checkbox_Field( 
+				'post_statuses_as_parent', 
+				__( 'Allow all post statuses in parents option', 'hwp-previews' ), 
+				__( 'By default WordPress only allows published posts to be parents. This option allows posts of all statuses to be used as parent within hierarchical post types.', 'hwp-previews' ) 
+			);
 		}
 
-		$fields[] = new Checkbox_Field( 'in_iframe', sprintf( __( 'Load previews in iframe', 'hwp-previews' ), $label ) );
+		$fields[] = new Checkbox_Field( 
+			'in_iframe', 
+			sprintf( __( 'Load previews in iframe', 'hwp-previews' ), $label ),
+			__( 'With this option enabled, headless previews will be displayed inside an iframe on the preview page, without leaving WordPress.', 'hwp-previews' ) 
+		);
 		$fields[] = new Text_Input_Field(
 			'preview_url',
 			// translators: %s is the label of the post type.
 			sprintf( __( 'Preview URL for %s', 'hwp-previews' ), $label ),
+			__( 'Construct your preview URL using the tags on the right. You can add any parameters needed to support headless previews.', 'hwp-previews' ) ,
 			"https://localhost:3000/{$post_type}?preview=true&post_id={ID}&name={slug}",
-			'large-text code hwp-previews-url' // The class is being used as a query for the JS.
+			'code hwp-previews-url' // The class is being used as a query for the JS.
 		);
 
 		return $fields;

--- a/plugins/hwp-previews/src/Plugin.php
+++ b/plugins/hwp-previews/src/Plugin.php
@@ -305,12 +305,12 @@ class Plugin {
 				true
 			);
 
-        	wp_enqueue_style(
+			wp_enqueue_style(
 				self::PLUGIN_CSS_HANDLE,
 				trailingslashit( $this->plugin_url ) . self::PLUGIN_CSS_SRC,
 				[],
 				$this->version
-        	);
+			);
 		} );
 	}
 
@@ -690,7 +690,7 @@ class Plugin {
 			'preview_url',
 			// translators: %s is the label of the post type.
 			sprintf( __( 'Preview URL for %s', 'hwp-previews' ), $label ),
-			__( 'Construct your preview URL using the tags on the right. You can add any parameters needed to support headless previews.', 'hwp-previews' ) ,
+			__( 'Construct your preview URL using the tags on the right. You can add any parameters needed to support headless previews.', 'hwp-previews' ),
 			"https://localhost:3000/{$post_type}?preview=true&post_id={ID}&name={slug}",
 			'code hwp-previews-url' // The class is being used as a query for the JS.
 		);

--- a/plugins/hwp-previews/src/Settings/Fields/Abstract_Settings_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Abstract_Settings_Field.php
@@ -41,6 +41,13 @@ abstract class Abstract_Settings_Field {
 	private string $post_type;
 
 	/**
+	 * The description field to show in the tooltip.
+	 *
+	 * @var string
+	 */
+	private string $description;
+
+	/**
 	 * Render the settings field.
 	 *
 	 * @param array<string, mixed> $option_value Settings value.
@@ -59,11 +66,13 @@ abstract class Abstract_Settings_Field {
 	public function __construct(
 		string $id,
 		string $title,
-		string $css_class = ''
+		string $css_class = '',
+		string $description = ''
 	) {
 		$this->id    = $id;
 		$this->title = $title;
 		$this->class = $css_class;
+		$this->description = $description;
 	}
 
 	/**
@@ -113,6 +122,15 @@ abstract class Abstract_Settings_Field {
 	 * Callback for the settings field.
 	 */
 	public function settings_field_callback(): void {
+		printf(
+			'<div tabindex="0" aria-describedby="%2$s-tooltip" class="hwp-previews-tooltip">
+				<span class="dashicons dashicons-editor-help"></span>
+				<span id="%2$s-tooltip" class="tooltip-text description">%1$s</span>
+			</div>',
+			esc_attr( $this->description ),
+			esc_attr( $this->settings_key )
+		);
+
 		$this->render_field(
 			$this->get_setting_value( $this->settings_key, $this->post_type ),
 			$this->settings_key,

--- a/plugins/hwp-previews/src/Settings/Fields/Abstract_Settings_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Abstract_Settings_Field.php
@@ -69,9 +69,9 @@ abstract class Abstract_Settings_Field {
 		string $css_class = '',
 		string $description = ''
 	) {
-		$this->id    = $id;
-		$this->title = $title;
-		$this->class = $css_class;
+		$this->id          = $id;
+		$this->title       = $title;
+		$this->class       = $css_class;
 		$this->description = $description;
 	}
 

--- a/plugins/hwp-previews/src/Settings/Fields/Checkbox_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Checkbox_Field.php
@@ -20,8 +20,8 @@ class Checkbox_Field extends Abstract_Settings_Field {
 	 * @param bool   $default_value The default value for the field.
 	 * @param string $css_class The settings field class.
 	 */
-	public function __construct( string $id, string $title, bool $default_value = false, string $css_class = '' ) {
-		parent::__construct( $id, $title, $css_class );
+	public function __construct( string $id, string $title, string $description = '', bool $default_value = false, string $css_class = '' ) {
+		parent::__construct( $id, $title, $css_class, $description );
 
 		$this->default = $default_value;
 	}

--- a/plugins/hwp-previews/src/Settings/Fields/Checkbox_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Checkbox_Field.php
@@ -17,6 +17,7 @@ class Checkbox_Field extends Abstract_Settings_Field {
 	 *
 	 * @param string $id The settings field ID.
 	 * @param string $title The settings field title.
+	 * @param string $description The settings field description.
 	 * @param bool   $default_value The default value for the field.
 	 * @param string $css_class The settings field class.
 	 */

--- a/plugins/hwp-previews/src/Settings/Fields/Text_Input_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Text_Input_Field.php
@@ -20,8 +20,8 @@ class Text_Input_Field extends Abstract_Settings_Field {
 	 * @param string $default_value The default value for the field.
 	 * @param string $css_class The settings field class.
 	 */
-	public function __construct( string $id, string $title, string $default_value = '', string $css_class = '' ) {
-		parent::__construct( $id, $title, $css_class );
+	public function __construct( string $id, string $title, string $description = '', string $default_value = '', string $css_class = '' ) {
+		parent::__construct( $id, $title, $css_class, $description );
 
 		$this->default = $default_value;
 	}

--- a/plugins/hwp-previews/src/Settings/Fields/Text_Input_Field.php
+++ b/plugins/hwp-previews/src/Settings/Fields/Text_Input_Field.php
@@ -17,6 +17,7 @@ class Text_Input_Field extends Abstract_Settings_Field {
 	 *
 	 * @param string $id The settings field ID.
 	 * @param string $title The settings field title.
+	 * @param string $description The settings field description.
 	 * @param string $default_value The default value for the field.
 	 * @param string $css_class The settings field class.
 	 */


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

This PR adds accessible tooltips to the settings in HWP Previews plugin. Tooltips describe the setting in detail.

## Related Issue
- #180 

## Dependant PRs
N/A

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
Tested on WP 6.8.1.

## Screenshots
![Screenshot 2025-05-23 at 11 10 39](https://github.com/user-attachments/assets/d75602b2-91b3-4e92-a11f-c77402022395)
![Screenshot 2025-05-23 at 11 10 47](https://github.com/user-attachments/assets/32b6f030-cce3-45c1-a30e-d1528d5949ba)
![Screenshot 2025-05-23 at 11 10 44](https://github.com/user-attachments/assets/05e10aa5-7c77-468e-90c2-9d22b8cd9b72)


## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
