### PR TITLE
ci: Improve plugin artifact bot to reuse comments in PRs

### DIFF
--- a/.github/workflows/plugin-artifact-for-pr.yml
+++ b/.github/workflows/plugin-artifact-for-pr.yml
@@ -59,6 +59,7 @@ jobs:
             
             if (botComment) {
               // Update existing comment
+              core.info(`Updating existing comment with ID: ${botComment.id}`);
               await github.rest.issues.updateComment({
                 comment_id: botComment.id,
                 owner: context.repo.owner,


### PR DESCRIPTION
This pull request updates the workflow for posting plugin artifact links on pull requests. The main change ensures that the bot checks for an existing comment and updates it instead of creating a new one each time, improving comment management and reducing duplication.

Enhancements to comment management:

* [`.github/workflows/plugin-artifact-for-pr.yml`](diffhunk://#diff-dc2461ae223a4df5b77a04a03d29cfcb3c0e2c79ab0c72ef8282657fbc4234aaL42-R73): Added logic to find existing comments from the bot and update them if they already mention the plugin artifact, instead of creating new comments. This prevents duplicate comments and keeps the pull request cleaner.

![download](https://github.com/user-attachments/assets/6713da60-3754-4f1c-b0b4-545b55e59b6f)
