### PR TITLE
fix: remove URI parameter

### DIFF
--- a/plugins/hwp-previews/README.md
+++ b/plugins/hwp-previews/README.md
@@ -36,7 +36,6 @@ With HWP Previews, you can define dynamic URL templates, enforce unique slugs fo
 	* `{slug}` – Post slug
 	* `{parent_ID}` – Parent post ID (hierarchical types)
 	* `{type}` – Post type slug
-	* `{uri}` – Page URI/path
 	* `{template}` – Template filename
 
 * **Unique Post Slugs**: Force unique slugs for all post statuses in the post status config.

--- a/plugins/hwp-previews/src/Preview/Parameter/Preview_Parameter_Registry.php
+++ b/plugins/hwp-previews/src/Preview/Parameter/Preview_Parameter_Registry.php
@@ -62,8 +62,6 @@ class Preview_Parameter_Registry {
 			)->register(
 				new Preview_Parameter( 'type', static fn( WP_Post $post ) => $post->post_type, 'The post type, like post or page.' )
 			)->register(
-				new Preview_Parameter( 'uri', static fn( WP_Post $post ) => (string) get_page_uri( $post ), 'The URI path for a page.' )
-			)->register(
 				new Preview_Parameter( 'template', static fn( WP_Post $post ) => (string) get_page_template_slug( $post ), 'Specific template filename for a given post.' )
 			);
 


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
URI parameter leads to misunderstandings (missing in draft posts) and bugs (#201) and adds little to no value the actual functionality. Unless explicitly requested we don't need to keep it.

## Related Issue
- #201 

## Dependant PRs
N/A

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [x] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
Manually, E2E

## Screenshots
N/A

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
