### PR TITLE
fix: add unsaved changes warning

### DIFF
--- a/plugins/hwp-previews/assets/js/hwp-previews.js
+++ b/plugins/hwp-previews/assets/js/hwp-previews.js
@@ -1,4 +1,8 @@
 document.addEventListener("DOMContentLoaded", () => {
+	// --------------------------------------------------------
+	// Parameter buttons
+	// --------------------------------------------------------
+
 	const buttons = document.querySelectorAll(".hwp-previews-insert-tag");
 	const input = document.querySelector(".hwp-previews-url");
 
@@ -40,4 +44,36 @@ document.addEventListener("DOMContentLoaded", () => {
 	for (const button of buttons) {
 		button.addEventListener("click", insertTag);
 	}
+
+	// --------------------------------------------------------
+	// Unsaved changes warning
+	// --------------------------------------------------------
+
+	// Select the form to monitor for changes
+	const formElement = document.querySelector("form");
+
+	function getFormState(form) {
+		const data = new FormData(form);
+		return JSON.stringify(Array.from(data.entries()));
+	}
+
+	// Save the initial state of the form for later comparison
+	const initialState = getFormState(formElement);
+
+	// Warn the user if they try to leave with unsaved changes
+	function beforeUnload(e) {
+		const formState = getFormState(formElement);
+
+		if (formState !== initialState) {
+			e.preventDefault();
+			e.returnValue = true;
+		}
+	}
+
+	window.addEventListener("beforeunload", beforeUnload);
+
+	// Remove the warning on submit so it doesn't appear when saving
+	formElement.addEventListener("submit", function () {
+		window.removeEventListener("beforeunload", beforeUnload);
+	});
 });


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
This PR adds a `beforeUnload` event handler to warn users about unsaved changes.

## Related Issue
- #195 

## Dependant PRs
N/A

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [x] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
Manual, e2e

## Screenshots
![Screenshot 2025-06-18 at 17 31 59](https://github.com/user-attachments/assets/52f21e3e-6d20-47d4-bd82-f2a80168748e)

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
