### PR TITLE
chore: Fix tag release process

### DIFF
--- a/.changeset/soft-owls-breathe.md
+++ b/.changeset/soft-owls-breathe.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/hwp-previews-wordpress-plugin": patch
+---
+
+chore: Renamed composer name to "hwp-previews" to fix composer installation issue.

--- a/.github/workflows/pre-release-tag.yml
+++ b/.github/workflows/pre-release-tag.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - "plugins/*/*"
+      - "plugins/*/**"
 
 permissions:
   contents: write
@@ -47,14 +47,14 @@ jobs:
       - name: Get changed plugin directory
         id: plugin
         run: |
-          # Get files changed in the merged PR
-          plugin=$(git diff --name-only HEAD~1 HEAD | grep '^plugins/' | head -1 | cut -d/ -f2)
-          if [ -z "$plugin" ]; then
+            # Get files changed in the merged PR, only match plugins/<plugin>/...
+            plugin=$(git diff --name-only HEAD~1 HEAD | grep '^plugins/[^/]\+/' | grep -v '^plugins/composer-packages.json' | head -1 | cut -d/ -f2)
+            if [ -z "$plugin" ]; then
             # Fallback: extract from branch name if no plugin changes detected
             branch_name="${{ github.head_ref }}"
             plugin=$(echo "$branch_name" | sed 's/release\/\([^-]*\)-.*/\1/')
-          fi
-          echo "plugin_slug=$plugin" >> $GITHUB_OUTPUT
+            fi
+            echo "plugin_slug=$plugin" >> $GITHUB_OUTPUT
 
       - name: Validate plugin detection
         run: |

--- a/plugins/composer-packages.json
+++ b/plugins/composer-packages.json
@@ -1,32 +1,6 @@
 {
   "packages": {
     "wpengine/hwp-previews": {
-      "0.0.7": {
-        "name": "wpengine/hwp-previews",
-        "version": "0.0.7",
-        "type": "wordpress-plugin",
-        "description": "A WordPress plugin for headless previews.",
-        "homepage": "https://github.com/wpengine/hwptoolkit",
-        "license": "GPL-2.0",
-        "authors": [
-          {
-            "name": "WP Engine Headless OSS Development Team",
-            "email": "headless-oss@wpengine.com",
-            "homepage": "https://wpengine.com/"
-          }
-        ],
-        "support": {
-          "issues": "https://github.com/wpengine/hwptoolkit/issues",
-          "email": "support@wpengine.com"
-        },
-        "dist": {
-          "url": "https://github.com/wpengine/hwptoolkit/releases/download/%40wpengine%2Fhwp-previews-wordpress-plugin-0.0.7/hwp-previews.zip",
-          "type": "zip"
-        },
-        "require": {
-          "composer/installers": "~1.0 || ~2.0"
-        }
-      },
       "0.0.6": {
         "name": "wpengine/hwp-previews",
         "version": "0.0.6",

--- a/plugins/hwp-previews/CHANGELOG.md
+++ b/plugins/hwp-previews/CHANGELOG.md
@@ -1,11 +1,5 @@
 # HWP Previews
 
-## 0.0.7
-
-### Patch Changes
-
-- [#315](https://github.com/wpengine/hwptoolkit/pull/315) [`a59bd2b`](https://github.com/wpengine/hwptoolkit/commit/a59bd2b22e76b0c10044b4c0cd5bc0e15e23e4bf) Thanks [@colinmurphy](https://github.com/colinmurphy)! - chore: Fixed previews composer name to "hwp-previews" to fix composer install issue.
-
 ## 0.0.6
 
 ### Patch Changes

--- a/plugins/hwp-previews/composer.json
+++ b/plugins/hwp-previews/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "A WordPress plugin for headless previews.",
 	"license": "GPL-2.0",
-	"version": "0.0.7",
+	"version": "0.0.6",
 	"authors": [
 		{
 			"name": "WP Engine Headless OSS Development Team",

--- a/plugins/hwp-previews/hwp-previews.php
+++ b/plugins/hwp-previews/hwp-previews.php
@@ -7,7 +7,7 @@
  * Author: WPEngine Headless OSS Team
  * Author URI: https://github.com/wpengine
  * Update URI: https://github.com/wpengine/hwptoolkit
- * Version: 0.0.7
+ * Version: 0.0.6
  * Text Domain: hwp-previews
  * Domain Path: /languages
  * Requires at least: 6.0
@@ -67,7 +67,7 @@ if ( ! function_exists( 'hwp_previews_constants' ) ) {
 	 */
 	function hwp_previews_constants(): void {
 		if ( ! defined( 'HWP_PREVIEWS_VERSION' ) ) {
-			define( 'HWP_PREVIEWS_VERSION', '0.0.7' );
+			define( 'HWP_PREVIEWS_VERSION', '0.0.6' );
 		}
 
 		if ( ! defined( 'HWP_PREVIEWS_PLUGIN_DIR' ) ) {

--- a/plugins/hwp-previews/package.json
+++ b/plugins/hwp-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wpengine/hwp-previews-wordpress-plugin",
-	"version": "0.0.7",
+	"version": "0.0.6",
 	"private": true,
 	"description": "Headless Previews solution for WordPress: fully configurable preview URLs via the settings page.",
 	"scripts": {

--- a/plugins/hwp-previews/readme.txt
+++ b/plugins/hwp-previews/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, Headless, Previews, WPGraphQL, React, Rest
 Requires at least: 6.0
 Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 0.0.7
+Stable tag: 0.0.6
 License: GPL-2.0
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description

Fixes plugin slug detection for creating the release tag not to use plugins/composer-packages.json.


## Related Issue
<!-- Please link any related issues here and describe the relationship.
     Examples:
     - "#123 - the issue that the PR resolves"
     - "#456 - this PR addresses part of the issue" -->

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
