### PR TITLE
fix: solve conflict with Faust redirect/rewrites and HWP Previews iframe mode

### DIFF
--- a/.changeset/twenty-snails-flow.md
+++ b/.changeset/twenty-snails-flow.md
@@ -1,0 +1,6 @@
+---
+"@wpengine/hwp-previews-wordpress-plugin": patch
+---
+
+1. Disables Faust front-end redirects for preview url's to solve the iframe conflict.
+2. Introduced methods in Faust_Integration to replace Faust-generated preview URLs with the site’s home URL as needed.

--- a/plugins/hwp-previews/src/Hooks/Preview_Hooks.php
+++ b/plugins/hwp-previews/src/Hooks/Preview_Hooks.php
@@ -12,6 +12,7 @@ use HWP\Previews\Preview\Post\Post_Settings_Service;
 use HWP\Previews\Preview\Post\Post_Type_Service;
 use HWP\Previews\Preview\Template\Template_Resolver_Service;
 use HWP\Previews\Preview\Url\Preview_Url_Resolver_Service;
+use HWP\Previews\Integration\Faust_Integration;
 use WP_Post;
 use WP_REST_Response;
 
@@ -226,6 +227,13 @@ class Preview_Hooks {
 
 		// If the iframe option is enabled, we need to resolve preview on the template redirect level.
 		if ( $post_type_service->is_iframe() ) {
+			$faust_helper = new Faust_Integration();
+
+			// If Faust post & category rewrites enabled, we should revert the preview link rewrites.
+			if( $faust_helper->is_faust_rewrites_enabled() ) {
+				return $faust_helper->replace_faust_preview_rewrite( $preview_link );
+			}
+
 			return $preview_link;
 		}
 

--- a/plugins/hwp-previews/src/Hooks/Preview_Hooks.php
+++ b/plugins/hwp-previews/src/Hooks/Preview_Hooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HWP\Previews\Hooks;
 
 use HWP\Previews\Admin\Settings\Fields\Settings_Field_Collection;
+use HWP\Previews\Integration\Faust_Integration;
 use HWP\Previews\Preview\Parameter\Preview_Parameter_Registry;
 use HWP\Previews\Preview\Post\Post_Editor_Service;
 use HWP\Previews\Preview\Post\Post_Preview_Service;
@@ -12,7 +13,6 @@ use HWP\Previews\Preview\Post\Post_Settings_Service;
 use HWP\Previews\Preview\Post\Post_Type_Service;
 use HWP\Previews\Preview\Template\Template_Resolver_Service;
 use HWP\Previews\Preview\Url\Preview_Url_Resolver_Service;
-use HWP\Previews\Integration\Faust_Integration;
 use WP_Post;
 use WP_REST_Response;
 
@@ -230,7 +230,7 @@ class Preview_Hooks {
 			$faust_helper = new Faust_Integration();
 
 			// If Faust post & category rewrites enabled, we should revert the preview link rewrites.
-			if( $faust_helper->is_faust_rewrites_enabled() ) {
+			if ( $faust_helper->is_faust_rewrites_enabled() ) {
 				return $faust_helper->replace_faust_preview_rewrite( $preview_link );
 			}
 

--- a/plugins/hwp-previews/src/Integration/Faust_Integration.php
+++ b/plugins/hwp-previews/src/Integration/Faust_Integration.php
@@ -186,7 +186,7 @@ class Faust_Integration {
 	 */
 	public function is_faust_rewrites_enabled(): bool {
 		if ( $this->get_faust_enabled() && function_exists( '\WPE\FaustWP\Settings\is_rewrites_enabled' ) ) {
-			return \WPE\FaustWP\Settings\is_rewrites_enabled();
+			return (bool) \WPE\FaustWP\Settings\is_rewrites_enabled();
 		}
 		
 		return false;

--- a/plugins/hwp-previews/src/Integration/Faust_Integration.php
+++ b/plugins/hwp-previews/src/Integration/Faust_Integration.php
@@ -185,9 +185,11 @@ class Faust_Integration {
 	 * Check if Faust rewrites are enabled.
 	 */
 	public function is_faust_rewrites_enabled(): bool {
-		return $this->get_faust_enabled()
-			&& function_exists( '\WPE\FaustWP\Settings\is_rewrites_enabled' )
-			&& \WPE\FaustWP\Settings\is_rewrites_enabled();
+		if ( $this->get_faust_enabled() && function_exists( '\WPE\FaustWP\Settings\is_rewrites_enabled' ) ) {
+			return \WPE\FaustWP\Settings\is_rewrites_enabled();
+		}
+		
+		return false;
 	}
 
 	/**
@@ -252,7 +254,7 @@ class Faust_Integration {
 				// Remove Faust's redirect callback.
 				remove_action( 'template_redirect', 'WPE\FaustWP\Deny_Public_Access\deny_public_access', 99 );
 			}
-		}, 10 );
+		}, 10, 0 );
 	}
 
 	/**

--- a/plugins/hwp-previews/src/Integration/Faust_Integration.php
+++ b/plugins/hwp-previews/src/Integration/Faust_Integration.php
@@ -202,7 +202,60 @@ class Faust_Integration {
 		// Remove FaustWP post preview link filter to avoid conflicts with our custom preview link generation.
 		remove_filter( 'preview_post_link', 'WPE\FaustWP\Replacement\post_preview_link', 1000 );
 
+		// Prevent Faust from redirecting preview URLs to the frontend in iframe mode.
+		$this->disable_faust_redirects();
+
 		$this->display_faust_admin_notice();
+	}
+
+	/**
+	 * Disable Faust's redirect functionality for preview URLs.
+	 */
+	protected function disable_faust_redirects(): void {
+		add_action( 'template_redirect', function(): void {
+			// Only run for preview URLs (e.g., ?p=ID&preview=true)
+			if ( isset( $_GET['preview'] ) && $_GET['preview'] === 'true' ) {
+				// Remove Faust's redirect callback
+				remove_action( 'template_redirect', 'WPE\FaustWP\Deny_Public_Access\deny_public_access', 99 );
+			}
+		}, 10 );
+	}
+
+	/**
+	 * Check if Faust rewrites are enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_faust_rewrites_enabled(): bool {
+		return $this->get_faust_enabled()
+			&& function_exists('\WPE\FaustWP\Settings\is_rewrites_enabled')
+			&& \WPE\FaustWP\Settings\is_rewrites_enabled();
+	}
+
+	/**
+	 * Replace Faust preview rewrites with the home URL.
+	 *
+	 * @param string $url The URL to be rewritten.
+	 *
+	 * @return string
+	 */
+	public function replace_faust_preview_rewrite($url): string {
+		if ( function_exists( '\WPE\FaustWP\Settings\faustwp_get_setting' ) ) {
+			$frontend_uri = \WPE\FaustWP\Settings\faustwp_get_setting( 'frontend_uri' );
+
+			// Return the URL as is if frontend uri is empty.
+			if ( ! $frontend_uri ) {
+				return $url;
+			}
+
+			$frontend_uri = trailingslashit( $frontend_uri );
+			$home_url     = trailingslashit( get_home_url() );
+
+
+			return str_replace( $frontend_uri, get_home_url(),  $url );
+		}
+
+		return $url;
 	}
 
 	/**

--- a/plugins/hwp-previews/src/Integration/Faust_Integration.php
+++ b/plugins/hwp-previews/src/Integration/Faust_Integration.php
@@ -198,22 +198,22 @@ class Faust_Integration {
 	 * @param string $url The URL to be rewritten.
 	 */
 	public function replace_faust_preview_rewrite($url): string {
-		if ( function_exists( '\WPE\FaustWP\Settings\faustwp_get_setting' ) ) {
-			$frontend_uri = \WPE\FaustWP\Settings\faustwp_get_setting( 'frontend_uri' );
-
-			// Return the URL as is if frontend uri is empty.
-			if ( ! $frontend_uri ) {
-				return $url;
-			}
-
-			$frontend_uri = trailingslashit( $frontend_uri );
-			$home_url     = trailingslashit( get_home_url() );
-
-
-			return str_replace( $frontend_uri, $home_url, $url );
+		if ( ! function_exists( '\WPE\FaustWP\Settings\faustwp_get_setting' ) ) {
+			return $url;
 		}
 
-		return $url;
+		$frontend_uri = \WPE\FaustWP\Settings\faustwp_get_setting( 'frontend_uri' );
+
+		// Return the URL as is if frontend uri is empty.
+		if ( ! $frontend_uri ) {
+			return $url;
+		}
+
+		$frontend_uri = trailingslashit( $frontend_uri );
+		$home_url     = trailingslashit( get_home_url() );
+
+
+		return str_replace( $frontend_uri, $home_url, $url );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
1. Disables Faust front-end redirects for preview url's to solve the iframe conflict.
2. Introduced methods in Faust_Integration to replace Faust-generated preview URLs with the site’s home URL as needed.

## Related Issue
- #244 

## Dependant PRs
N/A

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [x] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
Manually, E2E, PHP test suite

## Screenshots
N/A

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
