### PR TITLE
chore: Fixed changeset as should be added to root rather than the plugin.

### DIFF
--- a/.changeset/major-cougars-ask.md
+++ b/.changeset/major-cougars-ask.md
@@ -1,0 +1,5 @@
+---
+"@wpengine/hwp-previews-wordpress-plugin": patch
+---
+
+Fixed priority issue with ACF and Previews.

--- a/plugins/hwp-previews/.changeset/fix-acf-post-types-timing.md
+++ b/plugins/hwp-previews/.changeset/fix-acf-post-types-timing.md
@@ -1,5 +1,0 @@
----
-"@wpengine/hwp-previews-wordpress-plugin": patch
----
-
-Fixes priority issue with allowed post types set before ACF registers post types.


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
Creates a changeset. Removes incorrect place for changeset.

## Related Issue
<!-- Please link any related issues here and describe the relationship.
     Examples:
     - "#123 - the issue that the PR resolves"
     - "#456 - this PR addresses part of the issue" -->

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
