### PR TITLE
feat: new rule for excessive fields

### DIFF
--- a/plugins/wpgraphql-debug-extensions/src/Analysis/Rules/ExcessiveFields.php
+++ b/plugins/wpgraphql-debug-extensions/src/Analysis/Rules/ExcessiveFields.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * GraphQL Rule to identify excessive field selection (over-fetching).
+ *
+ * @package WPGraphQL\Debug\Analysis\Rules
+ */
+
+declare(strict_types=1);
+
+namespace WPGraphQL\Debug\Analysis\Rules;
+
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\Parser;
+use GraphQL\Language\Visitor;
+use GraphQL\Type\Schema;
+use GraphQL\Error\SyntaxError;
+use GraphQL\Utils\TypeInfo;
+use WPGraphQL\Debug\Analysis\Interfaces\AnalyzerItemInterface;
+
+class ExcessiveFields implements AnalyzerItemInterface {
+
+	/**
+	 * @var string|null A descriptive note about the analysis result.
+	 */
+	protected ?string $internalNote = null;
+
+	/**
+	 * Default field threshold.
+	 *
+	 * This value determines how many fields may be requested
+	 * on a single type before the rule considers it "excessive."
+	 *
+	 * Developers may override this using the
+	 * `graphql_debug_excessive_fields_threshold` WordPress filter.
+	 *
+	 * @var int
+	 */
+	protected int $fieldThreshold = 15;
+
+	/**
+	 * Analyze a GraphQL query for excessive field selections.
+	 *
+	 * @param string     $query     The raw GraphQL query string.
+	 * @param array      $variables Optional query variables.
+	 * @param Schema|null $schema   The GraphQL schema (required for type resolution).
+	 *
+	 * @return array{
+	 *     triggered: bool,
+	 *     message: string
+	 * }
+	 */
+	public function analyze( string $query, array $variables = [], ?Schema $schema = null ): array {
+		if ( null === $schema ) {
+			$schema = $this->query_analyzer->get_schema();
+		}
+		if ( null === $schema ) {
+			$this->internalNote = 'Excessive field selection analysis requires a GraphQL schema.';
+			return [ 
+				'triggered' => false,
+				'message' => $this->internalNote,
+			];
+		}
+
+		$fieldCounts = [];
+
+		try {
+			$ast = Parser::parse( $query );
+		} catch (SyntaxError $error) {
+			$this->internalNote = 'Excessive field selection analysis failed due to GraphQL syntax error: ' . $error->getMessage();
+			error_log( 'WPGraphQL Debug Extensions: ' . $this->internalNote );
+			return [ 
+				'triggered' => false,
+				'message' => $this->internalNote,
+			];
+		}
+
+		// Use TypeInfo to correctly resolve parent types during traversal
+		$typeInfo = new TypeInfo( $schema );
+
+		Visitor::visit(
+			$ast,
+			Visitor::visitWithTypeInfo(
+				$typeInfo,
+				[ 
+					'Field' => function (FieldNode $node) use (&$fieldCounts, $typeInfo) {
+						$parentType = $typeInfo->getParentType();
+						if ( $parentType ) {
+							$typeName = $parentType->name;
+							if ( ! isset( $fieldCounts[ $typeName ] ) ) {
+								$fieldCounts[ $typeName ] = 0;
+							}
+							$fieldCounts[ $typeName ]++;
+						}
+					},
+				]
+			)
+		);
+
+		$threshold = apply_filters(
+			'graphql_debug_rule_excessive_fields_threshold',
+			$this->fieldThreshold,
+			$query,
+			$variables,
+			$schema
+		);
+
+		$triggered = false;
+		$details = [];
+		foreach ( $fieldCounts as $type => $count ) {
+			if ( $count > $threshold ) {
+				$triggered = true;
+				$details[] = sprintf(
+					'Type "%s" selects %d fields, exceeding the threshold of %d.',
+					$type,
+					$count,
+					$threshold
+				);
+			}
+		}
+
+		$message = $triggered
+			? 'Over-fetching detected: ' . implode( ' ', $details )
+			: 'No excessive fields detected.';
+
+		$this->internalNote = $message;
+
+		return [ 
+			'triggered' => $triggered,
+			'message' => $message,
+		];
+	}
+
+	/**
+	 * Return the unique key for this analyzer rule.
+	 *
+	 * @return string
+	 */
+	public function getKey(): string {
+		return 'excessiveFieldsRule';
+	}
+}

--- a/plugins/wpgraphql-debug-extensions/src/Plugin.php
+++ b/plugins/wpgraphql-debug-extensions/src/Plugin.php
@@ -11,6 +11,7 @@ namespace WPGraphQL\Debug;
 
 use AxeWP\GraphQL\Helper\Helper;
 use WPGraphQL\Debug\Analysis\QueryAnalyzer;
+use WPGraphQL\Debug\Analysis\Rules\ExcessiveFields;
 use WPGraphQL\Debug\Analysis\Rules\NestedQuery;
 use WPGraphQL\Utils\QueryAnalyzer as OriginalQueryAnalyzer;
 use WPGraphQL\Debug\Analysis\Rules\Complexity;
@@ -86,6 +87,7 @@ if ( ! class_exists( 'WPGraphQL\Debug\Plugin' ) ) :
 						'complexity' => [ 'class' => Complexity::class, 'args' => [] ],
 						'unfiltered_lists' => [ 'class' => UnfilteredLists::class, 'args' => [] ],
 						'nested_query' => [ 'class' => NestedQuery::class, 'args' => [ ] ],
+						'excessive_fields' => [ 'class' => ExcessiveFields::class, 'args' => [ ] ],
 					];
 					$analyzer_items = apply_filters( 'graphql_debug_extensions_analyzer_items', $analyzer_items );
 


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
This PR introduces a new GraphQL debug rule: `ExcessiveFields`.  

The rule analyzes GraphQL queries to detect **over-fetching**, i.e., selecting an excessive number of fields for a single object type.  
It uses the GraphQL schema to traverse queries and count fields per type. If any type exceeds the configurable threshold, the rule is triggered.

Key features:
- Detects over-fetching across nested fields.
- Configurable threshold via WordPress filter: `graphql_debug_rule_excessive_fields_threshold`
- Full doc comments for maintainability.
- Returns structured output indicating whether the rule is triggered and a descriptive message.

## Related Issue


## Dependant PRs
- None

## Type of Change
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
- Queries with fewer fields than the threshold correctly return `"triggered": false`.
- Queries exceeding the threshold correctly return `"triggered": true`.
- Nested fields are counted properly using the schema.
- Threshold can be modified using the WordPress filter.

Example filter usage:

```php
// Set custom threshold to 20 fields
add_filter( 'graphql_debug_rule_excessive_fields_threshold', function( $default, $query, $variables, $schema ) {
    return 20;
}, 10, 4 )
```

## Example Queries

### Query that triggers the rule

```graphql
query InefficientQuery {
  posts(first: 1) {
    nodes {
      id
      title
      slug
      uri
      status
      date
      modified
      commentCount
      commentStatus
      pingStatus
      password
      link
      featuredImage {
        node {
          sourceUrl
          altText
          caption
        }
      }
      author {
        node {
          name
          email
          firstName
          lastName
          registeredDate
          description
          nickname
        }
      }
      content
      excerpt
    }
  }
}
```
Expected output:
```json
{
  "excessiveFieldsRule": {
    "triggered": true,
    "message": "Over-fetching detected: Type \"Post\" selects 16 fields, exceeding the threshold of 15."
  }
}
```
### Query that does NOT trigger the rule
```graphql
query EfficientQuery {
  posts(first: 1) {
    nodes {
      id
      title
      slug
      content
    }
  }
}
```
Expected output:
```json
{
  "excessiveFieldsRule": {
    "triggered": false,
    "message": "No excessive fields detected."
  }
}
```


