### PR TITLE
chore: Fix codeception workflow to calculate correctly the code coverage percentage

### DIFF
--- a/plugins/wpgraphql-logging/bin/run-codeception.sh
+++ b/plugins/wpgraphql-logging/bin/run-codeception.sh
@@ -69,8 +69,8 @@ run_tests() {
 		# Prefer XML summary for robustness; fallback to HTML if present
 		if [[ -f "tests/_output/coverage.xml" ]]; then
 			# Extract total statements and covered statements from the summary metrics line
-			total_statements=$(grep -Eo 'statements="[0-9]+"' "tests/_output/coverage.xml" | head -1 | grep -Eo '[0-9]+')
-			total_covered=$(grep -Eo 'coveredstatements="[0-9]+"' "tests/_output/coverage.xml" | head -1 | grep -Eo '[0-9]+')
+			total_statements=$(grep -Eo ' statements="[0-9]+"' "tests/_output/coverage.xml" | tail -1 | grep -Eo '[0-9]+')
+			total_covered=$(grep -Eo ' coveredstatements="[0-9]+"' "tests/_output/coverage.xml" | tail -1 | grep -Eo '[0-9]+')
 			if [[ -n "$total_statements" && -n "$total_covered" && "$total_statements" -gt 0 ]]; then
 				coverage_percent=$(awk "BEGIN { printf \"%.2f\", ($total_covered / $total_statements) * 100 }")
 			fi


### PR DESCRIPTION
… total rather than the first file.

<!-- Thank you for contributing to our WordPress open source project! -->

## Description
<!-- Please provide a clear and concise description of your changes -->
<!-- What problem does this PR solve? What functionality does it add/improve? -->

## Related Issue
<!-- Please link any related issues here and describe the relationship.
     Examples:
     - "#123 - the issue that the PR resolves"
     - "#456 - this PR addresses part of the issue" -->

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [x] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [x] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been highlighted, merged or published
