### PR TITLE
chore: Fix release/pre-release Github workflow

### DIFF
--- a/.github/workflows/pre-release-tag.yml
+++ b/.github/workflows/pre-release-tag.yml
@@ -90,6 +90,21 @@ jobs:
           echo "package_version=$package_version" >> $GITHUB_OUTPUT
           echo "PLUGIN_DIR=$PLUGIN_DIR" >> $GITHUB_OUTPUT
 
+      - name: Determine release type
+        id: release_type
+        run: |
+          VERSION="${{ steps.metadata.outputs.package_version }}"
+          IS_PRERELEASE=true
+          RELEASE_TITLE_PREFIX="Pre-release"
+
+          if [[ ! "$VERSION" =~ ^0\. ]]; then
+            IS_PRERELEASE=false
+            RELEASE_TITLE_PREFIX="Release"
+          fi
+
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+          echo "release_title_prefix=$RELEASE_TITLE_PREFIX" >> $GITHUB_OUTPUT
+
       - name: Create Git tag
         continue-on-error: false
         run: |
@@ -141,8 +156,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.TAG_NAME }}
-          name: "Pre-release ${{ steps.metadata.outputs.package_version }} for ${{ steps.metadata.outputs.package_name }}"
-          prerelease: true
+          name: "${{ steps.release_type.outputs.release_title_prefix }} ${{ steps.metadata.outputs.package_version }} for ${{ steps.metadata.outputs.package_name }}"
+          prerelease: ${{ steps.release_type.outputs.is_prerelease }}
           files: |
             ${{ steps.metadata.outputs.PLUGIN_DIR }}/plugin-build/${{ steps.plugin.outputs.plugin_slug }}.zip
         env:


### PR DESCRIPTION
## Description
Added a step to determine if the release is a pre-release or full release based on the version number. The release title and prerelease flag are now set dynamically, improving automation and reducing manual intervention.


## Related Issue

Fixes #500 

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [x] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's coding standards
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been highlighted, merged or published
