### PR TITLE
ci: automate plugin-check against toolkit plugins

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Set output
         id: detect
         run: |
-          if [ -z "${{ steps.plugin.outputs.plugins }}" ] || [ "${{ steps.plugin.outputs.plugins }}" = "[]" ]; then
+          # get_plugin_slug.sh outputs: slug, plugins (JSON array), has-plugins
+          if [ -z "${{ steps.plugin.outputs.slug }}" ]; then
             echo "plugins=[]" >> $GITHUB_OUTPUT
             echo "has-plugins=false" >> $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate WordPress plugin checks for any modified plugins in the `plugins/` directory. The workflow detects changed plugins and runs the official WordPress Plugin Check action for each, providing results as file annotations directly in pull requests.

**New WordPress Plugin Check Workflow:**

* Added `.github/workflows/plugin-check.yml` to automatically detect modified plugins and run the WordPress Plugin Check action in a matrix job for each changed plugin, with results shown as PR file annotations.