### PR TITLE
ci: Broaden plugin-check.yml trigger to run for all files

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -10,12 +10,12 @@ on:
     branches:
       - main
     paths:
-      - 'plugins/**/*.php'
+      - 'plugins/**'
   pull_request:
     branches:
       - main
     paths:
-      - 'plugins/**/*.php'
+      - 'plugins/**'
 
 jobs:
   detect-plugins:
@@ -73,3 +73,5 @@ jobs:
             vendor
             node_modules
             tests
+          ignore-warnings: true
+          include-experimental: false


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/plugin-check.yml` to broaden the file matching patterns and adjust the settings for the plugin check job. The main goal is to ensure the workflow triggers on any changes within the `plugins` directory and to fine-tune the behavior of the plugin detection job.

Workflow trigger updates:

* Broadened the workflow trigger patterns from only PHP files to all files within the `plugins` directory by changing the `paths` filter from `'plugins/**/*.php'` to `'plugins/**'` for both `push` and `pull_request` events.

Plugin check job configuration:

* Added `ignore-warnings: true` and `include-experimental: false` to the plugin detection job, which will suppress warnings and exclude experimental plugins from the check.