### PR TITLE
ci: Skip failing comment-on-pr job for Dependabot PRs

### DIFF
--- a/.github/workflows/plugin-artifact-for-pr.yml
+++ b/.github/workflows/plugin-artifact-for-pr.yml
@@ -47,10 +47,10 @@ jobs:
             composer-options: '--no-progress --optimize-autoloader --no-dev'
 
   comment-on-pr:
-    name: Comment with Artifact Links  
+    name: Comment with Artifact Links
     runs-on: ubuntu-latest
     needs: [detect-plugins, create-plugin-artifacts]
-    if: needs.detect-plugins.outputs.has-plugins == 'true'
+    if: needs.detect-plugins.outputs.has-plugins == 'true' && github.actor != 'dependabot[bot]'
     steps:
       - name: Comment with artifact links
         uses: actions/github-script@v7


### PR DESCRIPTION
<!-- Thank you for contributing to our WordPress open source project! -->

## Description
The `comment-on-pr job` in the Plugin Artifact workflow was failing on Dependabot PRs because Dependabot doesn't have permission to post comments via GITHUB_TOKEN. This fix skips the comment step for Dependabot PRs, letting the artifact creation jobs succeed without the permission error.

## Related Issue
- #582 

## Dependant PRs
<!-- List any PRs that have a dependency relationship with this one.
     Describe the nature of each dependency.
     Examples:
     - "#1234 - Must be merged BEFORE this PR (this PR relies on those changes)"
     - "#5678 - Must be merged WITH this PR (these changes must be deployed together)"
     - "#9012 - Should be merged AFTER this PR (depends on changes in this PR)" -->

## Type of Change
<!-- What types of changes does your code introduce? Put an x in all boxes that apply -->
- [ ] ✅ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] 📄 Example update (no functional changes)
- [ ] 📝 Documentation update
- [ ] 🔍 Performance improvement
- [ ] 🧪 Test update

## How Has This Been Tested?
<!-- Please describe the tests you've run to verify your changes -->
<!-- Include details of your testing environment, and the tests you ran -->

## Screenshots
<!-- If your change affects the UI or UX, provide before/after screenshots or videos -->
<!-- Delete this section if not applicable -->

## Checklist
<!-- Put an x in all the boxes that apply -->
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] My code follows the project's coding standards
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been highlighted, merged or published
