### PR TITLE
chore: add @wpengine/spcs as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wpengine/headless-open-source
+* @wpengine/headless-open-source @wpengine/spcs


### PR DESCRIPTION
Adds the @wpengine/spcs team as a CODEOWNER so Dependabot and other PRs route to the SPCS Jira board.