### PR TITLE
fix: Update CODEOWNERS for dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # jira:[18721] is where issues related to this repository should be ticketed
 
 # Dependency files: bot is co-owner so its approval satisfies CODEOWNERS for Dependabot PRs
-package.json @wpe-ie-deploy-bot @wpengine/spcs
-package-lock.json @wpe-ie-deploy-bot @wpengine/spcs
-composer.json @wpe-ie-deploy-bot @wpengine/spcs
-composer.lock @wpe-ie-deploy-bot @wpengine/spcs
-Dockerfile @wpe-ie-deploy-bot @wpengine/spcs
-docker-compose.yml @wpe-ie-deploy-bot @wpengine/spcs
+package.json @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco
+package-lock.json @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco
+composer.json @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco
+composer.lock @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco
+Dockerfile @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco
+docker-compose.yml @wpe-ie-deploy-bot @wpengine/spcs @colinmurphy @josephfusco

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -1,5 +1,7 @@
 name: Dependabot Automation
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `@colinmurphy` and `@josephfusco` to all dependency file CODEOWNERS rules (`composer.json`, `composer.lock`, `package.json`, etc.) so human approvals satisfy the requirement when the bot is unavailable
- Also re-adds both to the wildcard rule, which was accidentally dropped in #725
- Fixes the `dependabot-automation` workflow to trigger on `ready_for_review` so the bot re-approves if a Dependabot PR is ever converted out of draft

## Context

Specific CODEOWNERS rules override the wildcard, meaning `@colinmurphy` and `@josephfusco` were not code owners for dependency files. This caused PR #714 to be stuck waiting on `wpe-ie-deploy-bot` or `wpengine/spcs` even after a manual approval.

## Test plan

- [ ] Verify colinmurphy and josephfusco appear as requested reviewers on future Dependabot PRs touching dependency files
- [ ] Verify a Dependabot PR converted from draft re-triggers the automation workflow and gets bot approval